### PR TITLE
chore: add run-script-os to allow install directly from repo for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "scripts": {
     "lint": "npx eslint ./src --ignore-pattern node_modules --ext .js,.ts",
     "ts:check": "npx tsc --noEmit",
-    "build": "rm -rf dist && npx tsc",
+    "build": "run-script-os",
+    "build:windows": "(if exist dist rmdir /s /q dist) && npx tsc",
+    "build:default": "rm -rf dist && npx tsc",
     "project:clean": "cd example && npx react-native-clean-project --keep-node-modules --remove-iOS-build --remove-iOS-pods --remove-android-build --keep-brew --keep-pods && \\rm -fr ios/Pods",
     "prepare": "yarn build",
     "dev:sync": "yarn build && cd example/node_modules/rn-local-authentication/ && rm -rf android ios dist src && cd ../../../ && cp -r *podspec dist android ios src example/node_modules/rn-local-authentication/"
@@ -55,6 +57,7 @@
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-prettier": "^3.1.1",
     "prettier": "^1.19.1",
+    "run-script-os": "^1.1.6",
     "typescript": "^3.7.2"
   },
   "dependencies": {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,6 +1157,11 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+run-script-os@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/run-script-os/-/run-script-os-1.1.6.tgz#8b0177fb1b54c99a670f95c7fdc54f18b9c72347"
+  integrity sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==
+
 rxjs@^6.4.0:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"


### PR DESCRIPTION
## Intent
<!-- What are you trying to achieve with this PR?  -->
allow install directly from repo for windows

## Proposed changes
<!-- Compared to the target branch, what have you changed? -->
add run-script-os to be able to run different script based on OS to install it on windows
create build command for windows

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
